### PR TITLE
Add support for any request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Additionally you can pass an options object which should add more functionality 
 | ------------- |:-------------:|
 | imagesPropertyType  (**optional**) (ex: 'og')     | Fetches images only with the specified property, `meta[property='${imagesPropertyType}:image']` |
 | language  (**optional**) (ex: 'de', 'en-US')     | Fetch content with specific language |
+| headers  (**optional**) (ex: { 'user-agent': 'googlebot' })     | Add request headers to fetch call |
 
 
 ```javascript
@@ -48,6 +49,10 @@ LinkPreview.getPreview(
   {
     imagesPropertyType: 'og', // fetches only open-graph images
     language: 'fr-CA', // fetches site for French language
+    headers: {
+      'user-agent': 'googlebot', // fetches with googlebot crawler user agent
+      // ...other optional request headers
+    },
   })
   .then(data => console.debug(data));
 ```
@@ -122,4 +127,3 @@ yarn test
 ## License
 
 MIT license
-

--- a/index.js
+++ b/index.js
@@ -23,9 +23,10 @@ exports.getPreview = function (text, options) {
 
     if (detectedUrl) {
       var fetchOptions = {}
-      if (options && options.language) {
+      if (options) {
         fetchOptions.headers = {
-          'Accept-Language': options.language
+          'Accept-Language': options.language,
+          ...options.headers,
         }
       }
       fetch(detectedUrl, fetchOptions)


### PR DESCRIPTION
Our team needed to specify request headers for our branch links in order to get the right metadata back.

With this change devs can add any request headers they like. This has no breaking changes.

It would be nice to remove the `language` option and just allow it to be part of the `headers` option passed in however, that would cause a breaking change for any users already implementing the current code.

Tested to ensure functionality remains the same