### PR TITLE
Adds getPreviewFromContent() method for using link-preview-js with pre-fetched response object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ yarn add link-preview-js
 
 ## Usage
 
-Library exposes just one method `getLinkPreview`, you have to pass a string, doesn't matter if it is just a URL or a piece of text that contains a URL, the library will take care of parsing it and returning the info of first valid HTTP(S) URL info it finds.
+Library exposes two methods: 
 
-URL parsing is done via: https://gist.github.com/dperini/729294
+`getLinkPreview`, you have to pass a string, doesn't matter if it is just a URL or a piece of text that contains a URL, the library will take care of parsing it and returning the info of first valid HTTP(S) URL info it finds. (URL parsing is done via: https://gist.github.com/dperini/729294).
+
+`getPreviewFromContent`, useful for passing a pre-fetched Response object from an existing async/etc. call. Refer to example below for required object values.
 
 ```typescript
 import {getLinkPreview} from 'link-preview-js';
@@ -41,11 +43,23 @@ getLinkPreview('This is a text supposed to be parsed and the first link displaye
 // OR
 
 // a pre-fetched response object
-// (useful for CORS issues in Cordova apps, etc.)
 yourAjaxCall(url, (response) => {
   getPreviewFromContent(response)
     .then((data) => console.debug(data));
   })
+
+// The passed response object should include, at minimum:
+{
+  data: '<!DOCTYPE...><html>...',     // response content
+  headers: {
+    ...
+    // should include content-type
+    content-type: "text/html; charset=ISO-8859-1",
+    ...
+  },
+  url: 'https://domain.com/'          // resolved url
+}
+
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ getLinkPreview('This is a text supposed to be parsed and the first link displaye
   .then((data) => console.debug(data));
 ```
 
+// OR
+
+// a pre-fetched response object
+// (useful for CORS issues in Cordova apps, etc.)
+yourAjaxCall(url, (response) => {
+  getPreviewFromContent(response)
+    .then((data) => console.debug(data));
+  })
+```
+
 ## Options
 
 Additionally you can pass an options object which should add more functionality to the parsing of the link


### PR DESCRIPTION
Was really wanting to use this plugin within my Cordova (mobile) apps. 

**What does this "fix"?**
The nature of Cordova causes a lot of CORS issues when accessing outside domains from JS used within Cordova apps. In many cases, we use a plugin (e.g. [Cordova Http Plugin](https://www.npmjs.com/package/cordova-plugin-advanced-http) to access resources outside of the app's whitelisted domains.

**How does this fix work?**
Creates a new method named `getPreviewFromContent` in which you pass a pre-fetched Response object vs. the text/url you would otherwise pass in `getLinkPreview`.

Simply put: this just bypasses the `fetch` called by `getLinkPreview`, as the Response object is already provided.

**More Information on this PR**
-  Passes existing tests
- No new tests written
- Tested with a few domains, including Google.com

I'm in a bit of a hurry and would otherwise write more tests for this. I just wanted to get this in front of some eyes so if the idea itself is going to be rejected I don't have to waste my time :) 

Thank you for the plugin, it does everything I was looking for!


