### PR TITLE
Fix for SSRF vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Additionally you can pass an options object which should add more functionality 
 | imagesPropertyType (**optional**) (ex: 'og')                                           | Fetches images only with the specified property, `meta[property='${imagesPropertyType}:image']` |
 | headers (**optional**) (ex: { 'user-agent': 'googlebot', 'Accept-Language': 'en-US' }) |                                Add request headers to fetch call                                |
 | timeout (**optional**) (ex: 1000)                                                      |                                 Timeout for the request to fail                                 |
+| followRedirects (**optional**) (default false)                                                      |                                 For security reasons, the follow redirects option has been made optional                                 |
 
 ```javascript
 getLinkPreview("https://www.youtube.com/watch?v=MejbOFk7H6c", {

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Additionally you can pass an options object which should add more functionality 
 | imagesPropertyType (**optional**) (ex: 'og')                                           | Fetches images only with the specified property, `meta[property='${imagesPropertyType}:image']` |
 | headers (**optional**) (ex: { 'user-agent': 'googlebot', 'Accept-Language': 'en-US' }) |                                Add request headers to fetch call                                |
 | timeout (**optional**) (ex: 1000)                                                      |                                 Timeout for the request to fail                                 |
-| followRedirects (**optional**) (default false)                                                      |                                 For security reasons, the follow redirects option has been made optional                                 |
+| followRedirects (**optional**) (default false)                                                      |                                 For security reasons, the library does not automatically follow redirects, a malicious agent can exploit redirects to steal data, turn this on at your own risk                                 |
 
 ```javascript
 getLinkPreview("https://www.youtube.com/watch?v=MejbOFk7H6c", {

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -67,6 +67,7 @@ describe(`#getLinkPreview()`, () => {
   it(`should make request with different languages`, async () => {
     let linkInfo: any = await getLinkPreview(`https://www.hsbc.ca/`, {
       headers: { "Accept-Language": `fr` },
+      followRedirects: true,
     });
     expect(linkInfo.title).toEqual(`Particuliers | HSBC Canada`);
 

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -199,6 +199,16 @@ describe(`#getLinkPreview()`, () => {
       expect(e.message).toEqual("Request timeout");
     }
   });
+  
+  it(`should handle followRedirects option is false`, async () => {
+    try {
+      await getLinkPreview(`http://google.com/`, { followRedirects: false });
+    } catch (e) {
+      expect(e.message).toEqual(
+        `uri requested responds with a redirect, redirect mode is set to error: http://google.com/`,
+      );
+    }
+  });
 });
 
 describe(`#getPreviewFromContent`, () => {

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ interface ILinkPreviewOptions {
   imagesPropertyType?: string;
   proxyUrl?: string;
   timeout?: number;
+  followRedirects?: boolean;
 }
 
 interface IPreFetchedResource {
@@ -365,7 +366,9 @@ export async function getLinkPreview(
 
   const fetchOptions = {
     headers: options?.headers ?? {},
-    redirect: `follow` as `follow`,
+    redirect: options?.followRedirects
+      ? (`follow` as `follow`)
+      : (`error` as `error`),
     signal: controller.signal,
   };
 


### PR DESCRIPTION
https://github.com/ospfranco/link-preview-js/issues/105

@ospfranco Can we have a chance to check the url with regex before the redirect? So maybe that way library can check even if `followRedirects:true`