### PR TITLE
Follow Redirects Option Improvement

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -67,7 +67,7 @@ describe(`#getLinkPreview()`, () => {
   it(`should make request with different languages`, async () => {
     let linkInfo: any = await getLinkPreview(`https://www.hsbc.ca/`, {
       headers: { "Accept-Language": `fr` },
-      followRedirects: true,
+      followRedirects: `follow`,
     });
     expect(linkInfo.title).toEqual(`Particuliers | HSBC Canada`);
 
@@ -200,15 +200,42 @@ describe(`#getLinkPreview()`, () => {
     }
   });
   
-  it(`should handle followRedirects option is false`, async () => {
+  it(`should handle followRedirects option is error`, async () => {
     try {
-      await getLinkPreview(`http://google.com/`, { followRedirects: false });
+      await getLinkPreview(`http://google.com/`, { followRedirects: `error` });
     } catch (e) {
       expect(e.message).toEqual(
         `uri requested responds with a redirect, redirect mode is set to error: http://google.com/`,
       );
     }
   });
+
+  it(`should handle followRedirects option is manual but handleRedirects was not provided`, async () => {
+    try {
+      await getLinkPreview(`http://google.com/`, { followRedirects: `manual` });
+    } catch (e) {
+      expect(e.message).toEqual(
+        `link-preview-js followRedirects is set to manual, but no handleRedirects function was provided`
+      );
+    }
+  });
+
+  it(`should handle followRedirects option is manual with handleRedirects function`, async () => {
+    const response = await getLinkPreview(`http://google.com/`, {
+      followRedirects: `manual`,
+      handleRedirects: (forwardedURL: string) => {
+        if (forwardedURL !== `http://www.google.com/`) {
+          return false;
+        } 
+        return true;
+      },
+    });
+
+    expect(response.contentType).toEqual(`text/html`);
+    expect(response.url).toEqual(`http://www.google.com/`);
+    expect(response.mediaType).toEqual(`website`);
+  });
+
 });
 
 describe(`#getPreviewFromContent`, () => {

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -223,7 +223,7 @@ describe(`#getLinkPreview()`, () => {
   it(`should handle followRedirects option is manual with handleRedirects function`, async () => {
     const response = await getLinkPreview(`http://google.com/`, {
       followRedirects: `manual`,
-      handleRedirects: (forwardedURL: string) => {
+      handleRedirects: (baseURL: string, forwardedURL: string) => {
         if (forwardedURL !== `http://www.google.com/`) {
           return false;
         } 

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ interface ILinkPreviewOptions {
   timeout?: number;
   followRedirects?: `follow` | `error` | `manual`;
   resolveDNSHost?: (url: string) => Promise<string>;
-  handleRedirects?: (forwardedURL: string) => boolean;
+  handleRedirects?: (baseURL: string, forwardedURL: string) => boolean;
 }
 
 interface IPreFetchedResource {
@@ -401,10 +401,14 @@ export async function getLinkPreview(
   // https://github.com/node-fetch/node-fetch/issues/741
   const response = await fetch(fetchUrl, fetchOptions as any)
     .then((res) => {
-      if ((res.status === 301 || res.status === 302) && fetchOptions.redirect === `manual` && options?.handleRedirects) {
-        if(!options.handleRedirects(res.headers.get(`location`) || `` )){
+      if (
+        (res.status === 301 || res.status === 302) &&
+        fetchOptions.redirect === `manual` &&
+        options?.handleRedirects
+      ) {
+        if (!options.handleRedirects(fetchUrl, (res.headers.get(`location`) || ``))) {
           throw new Error(`link-preview-js could not handle redirect`);
-        } 
+        }
         return fetch(res.headers.get(`location`) || ``, fetchOptions as any);
       }
       return res;

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,7 @@ interface ILinkPreviewOptions {
   timeout?: number;
   followRedirects?: `follow` | `error` | `manual`;
   resolveDNSHost?: (url: string) => Promise<string>;
-  handleRedirects?: (url: string) => boolean;
+  handleRedirects?: (forwardedURL: string) => boolean;
 }
 
 interface IPreFetchedResource {

--- a/index.ts
+++ b/index.ts
@@ -9,8 +9,9 @@ interface ILinkPreviewOptions {
   imagesPropertyType?: string;
   proxyUrl?: string;
   timeout?: number;
-  followRedirects?: boolean;
+  followRedirects?: `follow` | `error` | `manual`;
   resolveDNSHost?: (url: string) => Promise<string>;
+  handleRedirects?: (url: string) => boolean;
 }
 
 interface IPreFetchedResource {
@@ -372,6 +373,10 @@ export async function getLinkPreview(
     throw new Error(`link-preview-js did not receive a valid a url or text`);
   }
 
+  if (options?.followRedirects === `manual` && !options?.handleRedirects) {
+    throw new Error(`link-preview-js followRedirects is set to manual, but no handleRedirects function was provided`);
+  }
+
   if (!!options?.resolveDNSHost) {
     const resolvedUrl = await options.resolveDNSHost(detectedUrl);
 
@@ -384,9 +389,7 @@ export async function getLinkPreview(
 
   const fetchOptions = {
     headers: options?.headers ?? {},
-    redirect: options?.followRedirects
-      ? (`follow` as `follow`)
-      : (`error` as `error`),
+    redirect: options?.followRedirects ?? `error`,
     signal: controller.signal,
   };
 
@@ -396,13 +399,22 @@ export async function getLinkPreview(
 
   // Seems like fetchOptions type definition is out of date
   // https://github.com/node-fetch/node-fetch/issues/741
-  const response = await fetch(fetchUrl, fetchOptions as any).catch((e) => {
-    if (e.name === `AbortError`) {
-      throw new Error(`Request timeout`);
-    }
-
-    throw e;
-  });
+  const response = await fetch(fetchUrl, fetchOptions as any)
+    .then((res) => {
+      if ((res.status === 301 || res.status === 302) && fetchOptions.redirect === `manual` && options?.handleRedirects) {
+        if(!options.handleRedirects(res.headers.get(`location`) || `` )){
+          throw new Error(`link-preview-js could not handle redirect`);
+        } 
+        return fetch(res.headers.get(`location`) || ``, fetchOptions as any);
+      }
+      return res;
+    })
+    .catch((e) => {
+      if (e.name === `AbortError`) {
+        throw new Error(`Request timeout`);
+      }
+      throw e;
+    });
 
   clearTimeout(timeoutCounter);
 


### PR DESCRIPTION
Hey @ospfranco after your `resolveDNSHost` i was testing my server and i encountered some redirection issues, some url use redirection for very basic reason for example `http://app.asana.com` redirect to `https://app.asana.com`  or `https://apple.com` redirec to `https://www.apple.com` we set followRedirects option `error` by default which is same in this pr but i would love to handle this simple redirection with my control so i create `handleRedirects` parameter as function type it will run only user set `followRedirects === manual` and that function allow to user control own redirection logic.
For example i will use like this 
```js
await getLinkPreview(`http://google.com/`, {
    followRedirects: `manual`,
    handleRedirects: (baseURL: string, forwardedURL: string) => {
      const urlObj = new URL(baseURL);
      const forwardedURLObj = new URL(forwardedURL);
      if (
        forwardedURLObj.hostname === urlObj.hostname ||
        forwardedURLObj.hostname === "www." + urlObj.hostname
      ) {
        return true;
      } else {
        return false;
      }
    },
  });
```